### PR TITLE
Fix readme file for examples and refactor method name

### DIFF
--- a/examples/cars/README.md
+++ b/examples/cars/README.md
@@ -17,5 +17,5 @@ And, you can run this example by:
 python main.py
 ```
 
-Now, check <http://localhost:8000> and you should see the swagger like:
+Now, check <http://localhost:8000/swagger> and you should see the swagger like:
 ![](./swagger.png)

--- a/examples/cars/blueprints/car.py
+++ b/examples/cars/blueprints/car.py
@@ -36,5 +36,5 @@ def car_put(request, car_id):
 @blueprint.delete("/<car_id:int>", strict_slashes=True)
 @doc.summary("Deletes a car")
 @doc.produces(Status)
-def car_put(request, car_id):
+def car_delete(request, car_id):
     return json(test_success)

--- a/examples/class_based_view/README.md
+++ b/examples/class_based_view/README.md
@@ -17,5 +17,5 @@ And, you can run this example by:
 python main.py
 ```
 
-Now, check <http://localhost:8000> and you should see the swagger like:
+Now, check <http://localhost:8000/swagger> and you should see the swagger like:
 ![](./swagger.png)


### PR DESCRIPTION
The `readme.md` files in the examples had the homepage as the swagger docs page. Added `/swagger` to the URL in the `readme`.

The delete function was named `car_put` in `/blueprints/car.py`. Changed it to `car_delete`.