### PR TITLE
Fix ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ from sanic import Sanic
 from sanic.response import json
 from sanic_openapi import swagger_blueprint
 
-app = Sanic()
+app = Sanic(name="AwesomeApi")
 app.blueprint(swagger_blueprint)
 
 


### PR DESCRIPTION
Update readme Documentation, since sanic release need name when first run.
See [this](https://github.com/sanic-org/sanic/blob/master/sanic/app.py#L60) for more detail