### PR TITLE
feat: docstring parsing

### DIFF
--- a/docs/sanic_openapi/api_factory.md
+++ b/docs/sanic_openapi/api_factory.md
@@ -1,3 +1,0 @@
-# API Factory
-
-To be done.

--- a/docs/sanic_openapi/docstring_parsing.md
+++ b/docs/sanic_openapi/docstring_parsing.md
@@ -1,0 +1,49 @@
+# Docstring Parsing
+
+sanic-openAPI will try to parse your function for documentation to add to the swagger interface, so for example:
+
+```python
+app = Sanic()
+app.blueprint(swagger_blueprint)
+
+
+@app.get("/test")
+async def test(request):
+	'''
+	This route is a test route
+
+	In can do lots of cool things
+	'''
+    return json({"Hello": "World"})
+```
+
+Would add that docstring to the openAPI route 'summary' and 'description' fields.
+
+For advanced users, you can also edit the yaml yourself, by adding the line "openapi:" followed by a valid yaml string.
+
+Note: the line "openapi:" should contain no whitespace before or after it.
+
+Note: any decorators you use on the function must utilise functools.wraps or similar in order to preserve the docstring if you would like to utilising the docstring parsing capability.
+
+```python
+app = Sanic()
+app.blueprint(swagger_blueprint)
+
+
+@app.get("/test")
+async def test(request):
+	'''
+	This route is a test route
+
+	In can do lots of cool things
+
+	openapi:
+	---
+	responses:
+	  '200':
+	    description: OK
+	'''
+    return json({"Hello": "World"})
+```
+
+If the yaml fails to parse for any reason, a warning will be printed, and the yaml will be ignored.

--- a/sanic_openapi/autodoc.py
+++ b/sanic_openapi/autodoc.py
@@ -1,0 +1,93 @@
+import inspect
+import warnings
+
+import yaml
+
+
+class OpenAPIDocstringParser(object):
+    def __init__(self, docstring):
+        """
+        Args:
+            docstring (str): docstring of function to be parsed
+        """
+        if docstring is None:
+            docstring = ""
+        self.docstring = inspect.cleandoc(docstring)
+
+    def to_openAPI_2(self):
+        """
+        Returns:
+            json style dict: dict to be read for the path by swagger 2.0 UI
+        """
+        raise NotImplementedError()
+
+    def to_openAPI_3(self):
+        """
+        Returns:
+            json style dict: dict to be read for the path by swagger 3.0.0 UI
+        """
+        raise NotImplementedError()
+
+
+class YamlStyleParametersParser(OpenAPIDocstringParser):
+    def _parse_no_yaml(self, doc):
+        """
+        Args:
+            doc (str): section of doc before yaml, or full section of doc
+        Returns:
+            json style dict: dict to be read for the path by swagger UI
+        """
+        # clean again in case further indentation can be removed,
+        # usually this do nothing...
+        doc = inspect.cleandoc(doc)
+
+        if len(doc) == 0:
+            return {}
+
+        lines = doc.split("\n")
+
+        if len(lines) == 1:
+            return {"summary": lines[0]}
+        else:
+            summary = lines.pop(0)
+
+            # remove empty lines at the beginning of the description
+            while len(lines) and lines[0].strip() == "":
+                lines.pop(0)
+
+            if len(lines) == 0:
+                return {"summary": summary}
+            else:
+                # use html tag to preserve linebreaks
+                return {"summary": summary, "description": "<br>".join(lines)}
+
+    def _parse_yaml(self, doc):
+        """
+        Args:
+            doc (str): section of doc detected as openapi yaml
+        Returns:
+            json style dict: dict to be read for the path by swagger UI
+        Warns:
+            UserWarning if the yaml couldn't be parsed
+        """
+        try:
+            return yaml.safe_load(doc)
+        except Exception as e:
+            warnings.warn("error parsing openAPI yaml, ignoring it. ({})".format(e))
+            return {}
+
+    def _parse_all(self):
+        if "openapi:\n" not in self.docstring:
+            return self._parse_no_yaml(self.docstring)
+
+        predoc, yamldoc = self.docstring.split("openapi:\n", 1)
+
+        conf = self._parse_no_yaml(predoc)
+        conf.update(self._parse_yaml(yamldoc))
+        return conf
+
+    def to_openAPI_2(self):
+        return self._parse_all()
+
+    def to_openAPI_3(self):
+        return self._parse_all()

--- a/sanic_openapi/autodoc.py
+++ b/sanic_openapi/autodoc.py
@@ -4,7 +4,7 @@ import warnings
 import yaml
 
 
-class OpenAPIDocstringParser(object):
+class OpenAPIDocstringParser:
     def __init__(self, docstring):
         """
         Args:

--- a/sanic_openapi/autodoc.py
+++ b/sanic_openapi/autodoc.py
@@ -5,7 +5,7 @@ import yaml
 
 
 class OpenAPIDocstringParser:
-    def __init__(self, docstring):
+    def __init__(self, docstring: str):
         """
         Args:
             docstring (str): docstring of function to be parsed
@@ -14,14 +14,14 @@ class OpenAPIDocstringParser:
             docstring = ""
         self.docstring = inspect.cleandoc(docstring)
 
-    def to_openAPI_2(self):
+    def to_openAPI_2(self) -> dict:
         """
         Returns:
             json style dict: dict to be read for the path by swagger 2.0 UI
         """
         raise NotImplementedError()
 
-    def to_openAPI_3(self):
+    def to_openAPI_3(self) -> dict:
         """
         Returns:
             json style dict: dict to be read for the path by swagger 3.0.0 UI
@@ -30,7 +30,7 @@ class OpenAPIDocstringParser:
 
 
 class YamlStyleParametersParser(OpenAPIDocstringParser):
-    def _parse_no_yaml(self, doc):
+    def _parse_no_yaml(self, doc: str) -> dict:
         """
         Args:
             doc (str): section of doc before yaml, or full section of doc
@@ -61,7 +61,7 @@ class YamlStyleParametersParser(OpenAPIDocstringParser):
                 # use html tag to preserve linebreaks
                 return {"summary": summary, "description": "<br>".join(lines)}
 
-    def _parse_yaml(self, doc):
+    def _parse_yaml(self, doc: str) -> dict:
         """
         Args:
             doc (str): section of doc detected as openapi yaml
@@ -76,7 +76,7 @@ class YamlStyleParametersParser(OpenAPIDocstringParser):
             warnings.warn("error parsing openAPI yaml, ignoring it. ({})".format(e))
             return {}
 
-    def _parse_all(self):
+    def _parse_all(self) -> dict:
         if "openapi:\n" not in self.docstring:
             return self._parse_no_yaml(self.docstring)
 
@@ -86,8 +86,8 @@ class YamlStyleParametersParser(OpenAPIDocstringParser):
         conf.update(self._parse_yaml(yamldoc))
         return conf
 
-    def to_openAPI_2(self):
+    def to_openAPI_2(self) -> dict:
         return self._parse_all()
 
-    def to_openAPI_3(self):
+    def to_openAPI_3(self) -> dict:
         return self._parse_all()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import re
 
 from setuptools import setup
 
-install_requires = ["sanic>=18.12.0"]
+install_requires = ["sanic>=18.12.0", "pyyaml"]
 
 dev_requires = ["black==19.3b0", "flake8==3.7.7", "isort==4.3.19"]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import re
 
 from setuptools import setup
 
-install_requires = ["sanic>=18.12.0", "pyyaml"]
+install_requires = ["sanic>=18.12.0", "pyyaml>=5.4.1"]
 
 dev_requires = ["black==19.3b0", "flake8==3.7.7", "isort==4.3.19"]
 

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -1,0 +1,47 @@
+from sanic_openapi import autodoc
+
+
+tests = []
+
+_ = ''
+
+tests.append({'doc': _, 'expects': {}})
+
+_ = 'one line docstring'
+
+tests.append({'doc': _, 'expects': {"summary": "one line docstring"}})
+
+_ = '''
+first line
+
+more lines
+'''
+
+tests.append({'doc': _, 'expects': {
+    "summary": "first line",
+    "description": "more lines"}})
+
+
+_ = '''
+first line
+
+more lines
+
+openapi:
+---
+responses:
+  '200':
+    description: OK
+'''
+
+tests.append({'doc': _, 'expects': {
+    "summary": "first line",
+    "description": "more lines",
+    "responses": {"200": {"description": "OK"}}}})
+
+
+def test_autodoc():
+    for t in tests:
+        parser = autodoc.YamlStyleParametersParser(t["doc"])
+        assert parser.to_openAPI_2() == t["expects"]
+        assert parser.to_openAPI_3() == t["expects"]


### PR DESCRIPTION
Closes https://github.com/sanic-org/sanic-openapi/issues/203


I decided to go with an approach where the user can specify their own yaml instead of going with a more complex parsing approach.

This has the upsides:

- https://github.com/flasgger/flasgger (openapi for flask) does something similar so users coming from there will be able to migrate easily
- enables user to modify the yaml however they want, no restrictions
- openapi3 compatibility straight away

this has the downside:

- corrupted yaml could be hard to debug for beginner users


Implementation notes: 
- if yaml parsing fails, raises a warning and then ignores the yaml
- if user uses doc decorators, it will use those first and then the yaml second 

For the future:

Somebody could add functools.wraps to the doc decorators if they would like to use them in conjunction with the docstring

I am not using those decorators so didnt look into that, actually the main point I wanted this feature was to avoid having to use the decorators


Heres a usage example: 
https://i.imgur.com/ViynuNY.png
https://i.imgur.com/oORSqRa.png

Feedback welcome, tagging people who could be interested @denisovkv @ruckc @ioggstream 
