### PR TITLE
deprecate sanic_openapi.api.API

### DIFF
--- a/sanic_openapi/api.py
+++ b/sanic_openapi/api.py
@@ -160,6 +160,15 @@ class API:
         Arguments:
             func: The decorated request handler function.
         """
+        import warnings
+
+        warnings.warn(
+            "sanic_openapi.api.API has been marked as deprecated, and may be removed"
+            " in 0.6.4. \n If you are using this class, please leave"
+            " an issue in https://github.com/sanic-org/sanic-openapi/issues",
+            UserWarning,
+        )
+
         if func is None:
             return partial(cls, **kwargs)
 


### PR DESCRIPTION
This class is quite cumbersome and doesn't seem to add much value to me, beyond that, it is completely undocumented so I would be surprised if anyone beyond it's creator is using it, would therefore recommend to remove it in 0.6.4

For anyone who doesn't know what the class does, it is basically a wrapper around multiple @doc decorators, but to me the boilerplate for the end user of creating a custom subclass of this class, and then the confusion for the end user of what that class would do, takes away the value of reducing the boilerplate of the decorators
