### PR TITLE
Multiple fixes and improvements

### DIFF
--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -1,5 +1,5 @@
 from .openapi2 import doc, openapi2_blueprint
-from .openapi3 import openapi, openapi3_blueprint
+from .openapi3 import openapi, openapi3_blueprint, specification
 
 swagger_blueprint = openapi2_blueprint
 
@@ -9,5 +9,6 @@ __all__ = [
     "swagger_blueprint",
     "openapi3_blueprint",
     "openapi",
+    "specification",
     "doc",
 ]

--- a/sanic_openapi/__init__.py
+++ b/sanic_openapi/__init__.py
@@ -3,7 +3,7 @@ from .openapi3 import openapi, openapi3_blueprint
 
 swagger_blueprint = openapi2_blueprint
 
-__version__ = "21.3.3"
+__version__ = "21.6.0"
 __all__ = [
     "openapi2_blueprint",
     "swagger_blueprint",

--- a/sanic_openapi/openapi2/blueprint.py
+++ b/sanic_openapi/openapi2/blueprint.py
@@ -54,6 +54,8 @@ def blueprint_factory():
         for blueprint_name, handler in get_blueprinted_routes(app):
             route_spec = route_specs[handler]
             route_spec.blueprint = blueprint_name
+            if route_spec.exclude:
+                continue
             if not route_spec.tags:
                 route_spec.tags.append(blueprint_name)
 
@@ -195,7 +197,9 @@ def blueprint_factory():
                 methods[_method.lower()] = endpoint
 
             if methods:
-                paths[uri] = methods
+                if uri not in paths:
+                    paths[uri] = {}
+                paths[uri].update(methods)
 
         # --------------------------------------------------------------- #
         # Definitions

--- a/sanic_openapi/openapi3/__init__.py
+++ b/sanic_openapi/openapi3/__init__.py
@@ -3,7 +3,6 @@
 """
 
 from collections import defaultdict
-
 from .builders import OperationBuilder, SpecificationBuilder
 
 # Static datastores, which get added to via the oas3.openapi decorators,

--- a/sanic_openapi/openapi3/__init__.py
+++ b/sanic_openapi/openapi3/__init__.py
@@ -14,24 +14,11 @@ except ImportError:
 # Static datastores, which get added to via the oas3.openapi decorators,
 # and then read from in the blueprint generation
 
-# operations: Dict[RouteHandler, OperationBuilder] = defaultdict(
-#     OperationBuilder
-# )
-# specification = SpecificationBuilder()
-operations = None
-specification = None
+operations: Dict[RouteHandler, OperationBuilder] = defaultdict(
+    OperationBuilder
+)
+specification = SpecificationBuilder()
 
-
-def setup():
-    global operations
-    global specification
-    if operations:
-        raise Exception(">>>")
-    operations = defaultdict(OperationBuilder)
-    specification = SpecificationBuilder()
-
-
-setup()
 
 from .blueprint import blueprint_factory  # noqa
 

--- a/sanic_openapi/openapi3/__init__.py
+++ b/sanic_openapi/openapi3/__init__.py
@@ -3,12 +3,20 @@
 """
 
 from collections import defaultdict
+from typing import Dict, TypeVar
 from .builders import OperationBuilder, SpecificationBuilder
+
+try:
+    from sanic.models.handler_types import RouteHandler
+except ImportError:
+    RouteHandler = TypeVar("RouteHandler")  # type: ignore
 
 # Static datastores, which get added to via the oas3.openapi decorators,
 # and then read from in the blueprint generation
 
-operations = defaultdict(OperationBuilder)
+operations: Dict[RouteHandler, OperationBuilder] = defaultdict(
+    OperationBuilder
+)
 specification = SpecificationBuilder()
 
 from .blueprint import blueprint_factory  # noqa

--- a/sanic_openapi/openapi3/__init__.py
+++ b/sanic_openapi/openapi3/__init__.py
@@ -14,10 +14,24 @@ except ImportError:
 # Static datastores, which get added to via the oas3.openapi decorators,
 # and then read from in the blueprint generation
 
-operations: Dict[RouteHandler, OperationBuilder] = defaultdict(
-    OperationBuilder
-)
-specification = SpecificationBuilder()
+# operations: Dict[RouteHandler, OperationBuilder] = defaultdict(
+#     OperationBuilder
+# )
+# specification = SpecificationBuilder()
+operations = None
+specification = None
+
+
+def setup():
+    global operations
+    global specification
+    if operations:
+        raise Exception(">>>")
+    operations = defaultdict(OperationBuilder)
+    specification = SpecificationBuilder()
+
+
+setup()
 
 from .blueprint import blueprint_factory  # noqa
 

--- a/sanic_openapi/openapi3/blueprint.py
+++ b/sanic_openapi/openapi3/blueprint.py
@@ -76,6 +76,10 @@ def blueprint_factory():
                 if hasattr(_handler, "view_class"):
                     _handler = getattr(_handler.view_class, method.lower())
                 operation = operations[_handler]
+
+                if operation._exclude:
+                    continue
+
                 docstring = inspect.getdoc(_handler)
 
                 if docstring:

--- a/sanic_openapi/openapi3/blueprint.py
+++ b/sanic_openapi/openapi3/blueprint.py
@@ -111,19 +111,19 @@ def add_static_info_to_spec_from_config(app, specification):
 
     Modifies specification in-place and returns None
     """
-    specification.describe(
+    specification._do_describe(
         getattr(app.config, "API_TITLE", "API"),
         getattr(app.config, "API_VERSION", "1.0.0"),
         getattr(app.config, "API_DESCRIPTION", None),
         getattr(app.config, "API_TERMS_OF_SERVICE", None),
     )
 
-    specification.license(
+    specification._do_license(
         getattr(app.config, "API_LICENSE_NAME", None),
         getattr(app.config, "API_LICENSE_URL", None),
     )
 
-    specification.contact(
+    specification._do_contact(
         getattr(app.config, "API_CONTACT_NAME", None),
         getattr(app.config, "API_CONTACT_URL", None),
         getattr(app.config, "API_CONTACT_EMAIL", None),

--- a/sanic_openapi/openapi3/builders.py
+++ b/sanic_openapi/openapi3/builders.py
@@ -47,6 +47,7 @@ class OperationBuilder:
         self.parameters = []
         self.responses = {}
         self._autodoc = None
+        self._exclude = False
 
     def name(self, value: str):
         self.operationId = value
@@ -107,6 +108,9 @@ class OperationBuilder:
     def autodoc(self, docstring: str):
         y = YamlStyleParametersParser(docstring)
         self._autodoc = y.to_openAPI_3()
+
+    def exclude(self, flag: bool = True):
+        self._exclude = flag
 
 
 class SpecificationBuilder:

--- a/sanic_openapi/openapi3/definitions.py
+++ b/sanic_openapi/openapi3/definitions.py
@@ -4,7 +4,7 @@ Classes defined from the OpenAPI 3.0 specifications.
 I.e., the objects described https://swagger.io/docs/specification
 
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Type, Union
 
 from .types import Definition, Schema
 
@@ -82,11 +82,20 @@ class MediaType(Definition):
 
 
 class Response(Definition):
-    content: Dict[str, MediaType]
-    description: str
+    content: Union[Any, Dict[str, Union[Any, MediaType]]]
+    description: Optional[str]
+    status: str
 
-    def __init__(self, content=None, **kwargs):
-        super().__init__(content=content, **kwargs)
+    def __init__(
+        self,
+        content: Optional[Union[Any, Dict[str, Union[Any, MediaType]]]] = None,
+        status: int = 200,
+        description: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            content=content, status=status, description=description, **kwargs
+        )
 
     @staticmethod
     def make(content, description: str = None, **kwargs):
@@ -99,12 +108,29 @@ class Response(Definition):
 
 
 class RequestBody(Definition):
-    description: str
-    required: bool
-    content: Dict[str, MediaType]
+    description: Optional[str]
+    required: Optional[bool]
+    content: Union[Any, Dict[str, Union[Any, MediaType]]]
 
-    def __init__(self, content: Dict[str, MediaType], **kwargs):
-        super().__init__(content=content, **kwargs)
+    def __init__(
+        self,
+        content: Union[Any, Dict[str, Union[Any, MediaType]]],
+        required: Optional[bool] = None,
+        description: Optional[str] = None,
+        **kwargs,
+    ):
+        """Can be initialized with content in one of a few ways:
+
+        RequestBody(SomeModel)
+        RequestBody({"application/json": SomeModel})
+        RequestBody({"application/json": {"name": str}})
+        """
+        super().__init__(
+            content=content,
+            required=required,
+            description=description,
+            **kwargs,
+        )
 
     @staticmethod
     def make(content: Any, **kwargs):
@@ -138,15 +164,34 @@ class Header(Definition):
 
 class Parameter(Definition):
     name: str
+    schema: Union[Type, Schema]
     location: str
-    description: str
-    required: bool
-    deprecated: bool
-    allowEmptyValue: bool
-    schema: Schema
+    description: Optional[str]
+    required: Optional[bool]
+    deprecated: Optional[bool]
+    allowEmptyValue: Optional[bool]
 
-    def __init__(self, name, schema: Schema, location="query", **kwargs):
-        super().__init__(name=name, schema=schema, location=location, **kwargs)
+    def __init__(
+        self,
+        name: str,
+        schema: Union[Type, Schema],
+        location: str = "query",
+        description: Optional[str] = None,
+        required: Optional[bool] = None,
+        deprecated: Optional[bool] = None,
+        allowEmptyValue: Optional[bool] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name,
+            schema=schema,
+            location=location,
+            description=description,
+            required=required,
+            deprecated=deprecated,
+            allowEmptyValue=allowEmptyValue,
+            **kwargs,
+        )
 
     @property
     def fields(self):

--- a/sanic_openapi/openapi3/definitions.py
+++ b/sanic_openapi/openapi3/definitions.py
@@ -259,13 +259,13 @@ class SecurityScheme(Definition):
         return values
 
     @staticmethod
-    def make(_type: str, cls: type, **kwargs):
+    def make(_type: str, cls: Type, **kwargs):
         params = cls.__dict__ if hasattr(cls, "__dict__") else {}
 
         return SecurityScheme(_type, **params, **kwargs)
 
 
-class ServerVariable:
+class ServerVariable(Definition):
     default: str
     description: str
     enum: List[str]

--- a/sanic_openapi/openapi3/openapi.py
+++ b/sanic_openapi/openapi3/openapi.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from sanic.blueprints import Blueprint
 from sanic.exceptions import SanicException
+
 from sanic_openapi.openapi3.definitions import (
     ExternalDocumentation,
     Parameter,
@@ -146,7 +147,7 @@ def definition(
             Union[Dict[str, Any], Response, Any],
             List[Union[Dict[str, Any], Response, Any]],
         ]
-    ] = None
+    ] = None,
 ):
     def inner(func):
         glbl = globals()

--- a/sanic_openapi/openapi3/openapi.py
+++ b/sanic_openapi/openapi3/openapi.py
@@ -3,7 +3,16 @@ This module provides decorators which append
 documentation to operations and components created in the blueprints.
 
 """
-from typing import Any
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+from sanic.blueprints import Blueprint
+from sanic.exceptions import SanicException
+from sanic_openapi.openapi3.definitions import (
+    ExternalDocumentation,
+    Parameter,
+    RequestBody,
+    Response,
+)
 
 from . import operations
 from .types import Array  # noqa
@@ -21,6 +30,19 @@ from .types import Object  # noqa
 from .types import Password  # noqa
 from .types import String  # noqa
 from .types import Time  # noqa
+
+
+def exclude(flag: bool = True, *, bp: Optional[Blueprint] = None):
+    if bp:
+        for route in bp.routes:
+            exclude(flag)(route.handler)
+        return
+
+    def inner(func):
+        operations[func].exclude(flag)
+        return func
+
+    return inner
 
 
 def operation(name: str):
@@ -103,6 +125,122 @@ def secured(*args, **kwargs):
 
     def inner(func):
         operations[func].secured(*args, **kwargs)
+        return func
+
+    return inner
+
+
+def definition(
+    *,
+    exclude: Optional[bool] = None,
+    operation: Optional[str] = None,
+    summary: Optional[str] = None,
+    description: Optional[str] = None,
+    document: Optional[Union[str, ExternalDocumentation]] = None,
+    tag: Optional[Union[str, Sequence[str]]] = None,
+    deprecated: bool = False,
+    body: Union[Dict[str, Any], RequestBody, Any] = None,
+    parameter: Union[Dict[str, Any], Parameter, str] = None,
+    response: Optional[
+        Union[
+            Union[Dict[str, Any], Response, Any],
+            List[Union[Dict[str, Any], Response, Any]],
+        ]
+    ] = None
+):
+    def inner(func):
+        glbl = globals()
+
+        if exclude is not None:
+            glbl["exclude"](exclude)(func)
+
+        if operation:
+            glbl["operation"](operation)(func)
+
+        if summary:
+            glbl["summary"](summary)(func)
+
+        if description:
+            glbl["description"](description)(func)
+
+        if document:
+            kwargs = {}
+            if isinstance(document, str):
+                kwargs["url"] = document
+            else:
+                kwargs["url"] = (document.fields["url"],)
+                kwargs["description"] = (document.fields["description"],)
+
+            glbl["document"](**kwargs)(func)
+
+        if tag:
+            taglist = []
+            op = (
+                "extend"
+                if isinstance(tag, (list, tuple, set, frozenset))
+                else "append"
+            )
+            getattr(taglist, op)(tag)
+            glbl["tag"](*taglist)(func)
+
+        if deprecated:
+            glbl["deprecated"]()(func)
+
+        if body:
+            kwargs = {}
+            if isinstance(body, RequestBody):
+                kwargs = body.fields
+            elif isinstance(body, dict):
+                kwargs = body
+            else:
+                kwargs["content"] = body
+            glbl["body"](**kwargs)(func)
+
+        if parameter:
+            kwargs = {}
+            if isinstance(parameter, Parameter):
+                kwargs = parameter.fields
+            elif isinstance(parameter, dict) and "name" in parameter:
+                kwargs = parameter
+            elif isinstance(parameter, str):
+                kwargs["name"] = parameter
+            else:
+                raise SanicException(
+                    "parameter must be a Parameter instance, a string, or "
+                    "a dictionary containing at least 'name'."
+                )
+
+            if "schema" not in kwargs:
+                kwargs["schema"] = str
+
+            glbl["parameter"](**kwargs)(func)
+
+        if response:
+            resplist = []
+            op = (
+                "extend"
+                if isinstance(response, (list, tuple, set, frozenset))
+                else "append"
+            )
+            getattr(resplist, op)(response)
+
+            for resp in resplist:
+                kwargs = {}
+                if isinstance(resp, Response):
+                    kwargs = resp.fields
+                elif isinstance(resp, dict):
+                    if "content" in resp:
+                        kwargs = resp
+                    else:
+                        kwargs["content"] = resp
+                else:
+                    kwargs["content"] = resp
+
+                if "status" not in kwargs:
+                    kwargs["status"] = 200
+
+                glbl["response"](**kwargs)(func)
+
         return func
 
     return inner

--- a/sanic_openapi/openapi3/openapi.py
+++ b/sanic_openapi/openapi3/openapi.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 from sanic.blueprints import Blueprint
 from sanic.exceptions import SanicException
+
 from sanic_openapi.openapi3.definitions import (
     ExternalDocumentation,
     Parameter,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=--durations=0 --cov=sanic_openapi --cov-config .coveragerc --cov-report html
+# addopts=--durations=0 --cov=sanic_openapi --cov-config .coveragerc --cov-report html
 
 [aliases]
 test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=--durations=0 --html=test_reports/report.html --self-contained-html --cov=sanic_openapi --cov-config .coveragerc --cov-report html
+addopts=--durations=0 --cov=sanic_openapi --cov-config .coveragerc --cov-report html
 
 [aliases]
 test=pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import itertools
 
 import pytest
 from sanic import Sanic
+
 from sanic_openapi import openapi2_blueprint, openapi3_blueprint
 
 app_ID = itertools.count()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,7 @@ import itertools
 
 import pytest
 from sanic import Sanic
-
-from sanic_openapi import openapi2_blueprint
+from sanic_openapi import openapi2_blueprint, openapi3_blueprint
 
 app_ID = itertools.count()
 
@@ -16,3 +15,13 @@ def app():
 
     # Clean up
     openapi2_blueprint.definitions = {}
+
+
+@pytest.fixture()
+def app3():
+    app = Sanic("test_{}".format(next(app_ID)))
+    app.blueprint(openapi3_blueprint)
+    yield app
+
+    # Clean up
+    openapi3_blueprint.definitions = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,3 @@ def app3():
     app = Sanic("test_{}".format(next(app_ID)))
     app.blueprint(openapi3_blueprint)
     yield app
-
-    # Clean up
-    openapi3_blueprint.definitions = {}

--- a/tests/samples/petstore.yaml
+++ b/tests/samples/petstore.yaml
@@ -1,0 +1,113 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+tags:
+  - name: pets
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/tests/test_oas3_blueprint.py
+++ b/tests/test_oas3_blueprint.py
@@ -1,0 +1,39 @@
+from sanic.blueprints import Blueprint
+from sanic_openapi import openapi
+
+
+def test_exclude_entire_blueprint(app3):
+    bp = Blueprint("noshow")
+
+    @bp.get("/")
+    def noshow(_):
+        ...
+
+    app3.blueprint(bp)
+    openapi.exclude(bp=bp)
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+
+    assert not response.json["paths"]
+    assert not response.json["tags"]
+
+
+def test_exclude_single_blueprint_route(app3):
+    bp = Blueprint("noshow")
+
+    @bp.get("/")
+    @openapi.exclude()
+    def noshow(_):
+        ...
+
+    @bp.get("/ok")
+    def ok(_):
+        ...
+
+    app3.blueprint(bp)
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+
+    assert "/ok" in response.json["paths"]
+    assert len(response.json["paths"]) == 1
+    assert len(response.json["tags"]) == 1

--- a/tests/test_oas3_blueprint.py
+++ b/tests/test_oas3_blueprint.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from sanic.blueprints import Blueprint
+
 from sanic_openapi import openapi, openapi3
 from sanic_openapi.openapi3.blueprint import blueprint_factory
 from sanic_openapi.openapi3.builders import (

--- a/tests/test_oas3_blueprint.py
+++ b/tests/test_oas3_blueprint.py
@@ -20,7 +20,12 @@ def test_exclude_entire_blueprint(app3):
     def noshow(_):
         ...
 
-    app3.router.reset()
+    # For 21.3+
+    try:
+        app3.router.reset()
+    except AttributeError:
+        ...
+
     app3.blueprint(bp)
     openapi.exclude(bp=bp)
 
@@ -46,7 +51,12 @@ def test_exclude_single_blueprint_route(app3):
     def ok(_):
         ...
 
-    app3.router.reset()
+    # For 21.3+
+    try:
+        app3.router.reset()
+    except AttributeError:
+        ...
+
     app3.blueprint(bp)
 
     _, response = app3.test_client.get("/swagger/swagger.json")

--- a/tests/test_oas3_definition.py
+++ b/tests/test_oas3_definition.py
@@ -1,0 +1,189 @@
+import pytest
+from sanic_openapi import openapi
+from sanic_openapi.openapi3.definitions import (
+    ExternalDocumentation,
+    Parameter,
+    RequestBody,
+    Response,
+    Tag,
+)
+from sanic_openapi.openapi3.types import Schema, _serialize
+
+
+class Name:
+    first_name: str
+    last_name: str
+
+
+class User:
+    name: Name
+
+
+def test_def_operation(app3):
+    @app3.post("/path")
+    @openapi.definition(
+        operation="operID",
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    op = response.json["paths"]["/path"]["post"]
+
+    assert op["operationId"] == "operID"
+
+
+def test_def_summary(app3):
+    @app3.post("/path")
+    @openapi.definition(
+        summary="Hello, world.",
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    op = response.json["paths"]["/path"]["post"]
+
+    assert op["summary"] == "Hello, world."
+
+
+def test_def_description(app3):
+    @app3.post("/path")
+    @openapi.definition(
+        description="Hello, world.",
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    op = response.json["paths"]["/path"]["post"]
+
+    assert op["description"] == "Hello, world."
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "foo",
+        Tag("foo"),
+        ["foo"],
+        [Tag("foo")],
+        [Tag("foo"), "bar"],
+    ),
+)
+def test_def_tag(app3, value):
+    @app3.post("/path")
+    @openapi.definition(
+        tag=value,
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    op = response.json["paths"]["/path"]["post"]
+    length = len(value) if isinstance(value, list) else 1
+
+    assert "foo" in op["tags"]
+    assert len(op["tags"]) == length
+
+
+@pytest.mark.parametrize(
+    "value",
+    ("http://somewhere", ExternalDocumentation("http://somewhere")),
+)
+def test_def_document(app3, value):
+    @app3.post("/path")
+    @openapi.definition(
+        document=value,
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    op = response.json["paths"]["/path"]["post"]
+
+    assert op["externalDocs"]["url"] == "http://somewhere"
+
+
+@pytest.mark.parametrize(
+    "media,value",
+    (
+        ("*/*", User),
+        ("*/*", {"*/*": User}),
+        ("*/*", {"content": {"*/*": User}}),
+        ("*/*", RequestBody(User)),
+        ("*/*", RequestBody(content=User)),
+        ("application/json", RequestBody({"application/json": User})),
+    ),
+)
+def test_def_body(app3, media, value):
+    @app3.post("/path")
+    @openapi.definition(
+        body=value,
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    body = response.json["paths"]["/path"]["post"]["requestBody"]
+
+    assert body["content"][media]["schema"] == _serialize(Schema.make(User))
+
+
+@pytest.mark.parametrize(
+    "type_,value",
+    (
+        ("string", "something"),
+        ("string", {"name": "something"}),
+        ("string", ["something", "else"]),
+        ("integer", {"name": "something", "schema": int}),
+        ("string", Parameter("something", str)),
+        ("string", [Parameter("something", str)]),
+    ),
+)
+def test_def_parameter(app3, value, type_):
+    @app3.post("/path")
+    @openapi.definition(
+        parameter=value,
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    params = response.json["paths"]["/path"]["post"]["parameters"]
+
+    length = len(value) if isinstance(value, list) else 1
+
+    assert len(params) == length
+    assert params[0]["name"] == "something"
+    assert params[0]["schema"]["type"] == type_
+
+
+@pytest.mark.parametrize(
+    "status,media,value",
+    (
+        (200, "*/*", User),
+        (200, "application/json", {"application/json": User}),
+        (200, "*/*", Response(User)),
+        (201, "*/*", Response(User, 201)),
+        (201, "*/*", [Response(User, 201), User]),
+        (200, "application/json", Response({"application/json": User})),
+    ),
+)
+def test_def_response(app3, status, media, value):
+    @app3.post("/path")
+    @openapi.definition(
+        response=value,
+    )
+    async def handler(request):
+        ...
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+    responses = response.json["paths"]["/path"]["post"]["responses"]
+
+    length = len(value) if isinstance(value, list) else 1
+
+    assert len(responses) == length
+    assert responses[f"{status}"]["content"][media] == {
+        "schema": _serialize(Schema.make(User))
+    }

--- a/tests/test_oas3_definition.py
+++ b/tests/test_oas3_definition.py
@@ -1,4 +1,5 @@
 import pytest
+
 from sanic_openapi import openapi
 from sanic_openapi.openapi3.definitions import (
     ExternalDocumentation,

--- a/tests/test_oas3_specification.py
+++ b/tests/test_oas3_specification.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import yaml
+
 from sanic_openapi import specification
 
 

--- a/tests/test_oas3_specification.py
+++ b/tests/test_oas3_specification.py
@@ -19,6 +19,15 @@ def test_raw(app3):
     with open(Path(__file__).parent / "samples" / "petstore.yaml", "r") as f:
         data = yaml.safe_load(f)
 
+    _, response = app3.test_client.get("/swagger/swagger.json")
+
+    path_count = len(response.json["paths"])
+    schema_count = len(
+        (response.json.get("components", {}) or {}).get("schemas", {})
+    )
+    servers_count = len(response.json["servers"])
+    tags_count = len(response.json["tags"])
+
     specification.tag("one")
     specification.raw(data)
     specification.url("http://foobar")
@@ -26,12 +35,13 @@ def test_raw(app3):
 
     _, response = app3.test_client.get("/swagger/swagger.json")
 
-    assert len(response.json["paths"]) == 2
-    assert len(response.json["components"]["schemas"]) == 3
-    assert len(response.json["servers"]) == 2
-    assert len(response.json["tags"]) == 3
+    assert len(response.json["paths"]) == path_count + 2
+    assert len(response.json["components"]["schemas"]) == schema_count + 3
+    assert len(response.json["servers"]) == servers_count + 2
+    assert len(response.json["tags"]) == tags_count + 3
 
     assert response.json["servers"][1]["url"] == "http://foobar"
-    assert {x["name"] for x in response.json["tags"]} == set(
-        ["one", "two", "pets"]
+    assert all(
+        x in {x["name"] for x in response.json["tags"]}
+        for x in ["one", "two", "pets"]
     )

--- a/tests/test_oas3_specification.py
+++ b/tests/test_oas3_specification.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import yaml
+from sanic_openapi import specification
+
+
+def test_apply_describe(app3):
+    title = "This is a test"
+    version = "1.1.1"
+    specification.describe(title, version=version)
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+
+    assert response.json["info"]["title"] == title
+    assert response.json["info"]["version"] == version
+
+
+def test_raw(app3):
+    with open(Path(__file__).parent / "samples" / "petstore.yaml", "r") as f:
+        data = yaml.safe_load(f)
+
+    specification.tag("one")
+    specification.raw(data)
+    specification.url("http://foobar")
+    specification.tag("two")
+
+    _, response = app3.test_client.get("/swagger/swagger.json")
+
+    assert len(response.json["paths"]) == 2
+    assert len(response.json["components"]["schemas"]) == 3
+    assert len(response.json["servers"]) == 2
+    assert len(response.json["tags"]) == 3
+
+    assert response.json["servers"][1]["url"] == "http://foobar"
+    assert {x["name"] for x in response.json["tags"]} == set(
+        ["one", "two", "pets"]
+    )


### PR DESCRIPTION
1. Fixes #240 
2. Fixes #239 
3. Adds `exclude` to OAS3
4. Adds `openapi.definition` decorator to OAS3
5. Adds support for reading from annotated class models
6. Adds `specification.raw()` method to OAS3 for adding specs directly

Here is an example of how the `definition` decorator could be used:

```python
class Name:
    first_name: str
    last_name: str


class User:
    name: Name


@app.post("/path")
@openapi.definition(
    operation="opeID",
    summary="This is a summary",
    description="This is a description",
    tag=["one", "two"],
    document="http://127.0.0.1:9999/doc",
    # body=RequestBody(content=User),
    body=RequestBody(User, True, "Hello"),
    # body=RequestBody({"application/json": {"name": str}}),
    # body={"*/*": User},
    parameter=Parameter("foo", int),
    # parameter={"required": True, "name": "something"},
    response=[
        Response(User, status=201),
        Response(Name, status=400),
    ],
    # response={"application/json": User
)
async def post_test(request):
    return json({"hello": "world"})
```