### PR TITLE
add sanic-testing package to test_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ doc_requires = [
 ]
 
 test_requires = [
+    "sanic-testing",
     "coverage==4.5.3",
     "pytest==4.6.2",
     "pytest-cov==2.7.1",


### PR DESCRIPTION
I don't know how workflows go without errors, but on a clean Windows host I have an error:
ModuleNotFoundError: No module named 'sanic_testing'.
So I added it to test_requires