### PR TITLE
Swagger specification OAS2.0 dont allow same "operationId" specified …

### DIFF
--- a/sanic_openapi/openapi2/blueprint.py
+++ b/sanic_openapi/openapi2/blueprint.py
@@ -179,7 +179,9 @@ def blueprint_factory():
 
                 endpoint = remove_nulls(
                     {
-                        "operationId": route_spec.operation or route_name,
+                        "operationId": route_spec.operation or "%s_%s" % (
+                            _method.lower(), route_name
+                        ),
                         "summary": route_spec.summary,
                         "description": route_spec.description,
                         "consumes": consumes_content_types,

--- a/sanic_openapi/openapi2/blueprint.py
+++ b/sanic_openapi/openapi2/blueprint.py
@@ -179,9 +179,8 @@ def blueprint_factory():
 
                 endpoint = remove_nulls(
                     {
-                        "operationId": route_spec.operation or "%s_%s" % (
-                            _method.lower(), route_name
-                        ),
+                        "operationId": route_spec.operation
+                        or "%s_%s" % (_method.lower(), route_name),
                         "summary": route_spec.summary,
                         "description": route_spec.description,
                         "consumes": consumes_content_types,


### PR DESCRIPTION
…in the route paths specifications.

When you use Sanic HTTPMethodView and define multiple methods in the views, multiple operationId with same string are created.
This commit include extra method string to generate different operationId's.

- This problem impact UI behavior because the accordion with same OperationId expand and colapse at the same time.
- Also affect the Swagger specification because you can't have operationId's repeated. 

```python

    class ViewConfigStaticRetrieversUsage(HTTPMethodView):
    @doc.produces(
        StaticRetrieversModel,
        description="Static retriever usage status",
        content_type="application/json",
    )
    async def get(self, request):
        ...

    @doc.consumes(StaticRetrieverStatusModel, location="body")
    @doc.produces(
        StaticRetrieversModel,
        description="Static retriever usage status updated",
        content_type="application/json",
    )
    async def put(self, request):
        ...
```

The swagger result is:
``` json
/config/static_providers": {
        "put": {
          "operationId": "Config.ViewConfigStaticRetrieversUsage",
          "consumes": [
            "application/json"
          ],
          ...
        },
        "get": {
          "operationId": "Config.ViewConfigStaticRetrieversUsage",
          "consumes": [
            "application/json"
          ],
          ...
      },`
```