### PR TITLE
remove deprecated CompositionView (as of Sanic 21.12.0)

### DIFF
--- a/docs/sanic_openapi2/document_routes.md
+++ b/docs/sanic_openapi2/document_routes.md
@@ -6,11 +6,9 @@ Sanic-OpenAPI support different ways to document APIs includes:
 * routes of `Blueprint` instance
 * routes of `HTTPMethodView` under `Sanic` instance
 * routes of `HTTPMethodView` under `Bluebprint` instance
-* routes of `CompositionView` under `Sanic` instance
 
 But with some exceptions:
 
-* Sanic-OpenAPI does not support routes of `CompositionView` under `Bluebprint` instance now.
 * Sanic-OpenAPI does not document routes with `OPTIONS` method.
 * Sanic-OpenAPI does not document routes which registered by `static()`.
 
@@ -172,42 +170,3 @@ if __name__ == "__main__":
 
 The result:
 ![](../_static/images/blueprint_class_based_view_example.png)
-
-
-## CompositionView Routes
-
-There is another class-based view named `CompositionView`. Sanic-OpenAPI also support to document routes under class-based view.
-
-```python
-from sanic import Sanic
-from sanic.response import text
-from sanic.views import CompositionView
-
-from sanic_openapi import openapi2_blueprint
-
-app = Sanic()
-app.blueprint(openapi2_blueprint)
-
-
-def get_handler(request):
-    return text("I am a get method")
-
-
-view = CompositionView()
-view.add(["GET"], get_handler)
-view.add(["POST", "PUT"], lambda request: text("I am a post/put method"))
-
-# Use the new view to handle requests to the base URL
-app.add_route(view, "/")
-
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000)
-
-```
-
-The Swagger will looks like:
-![](../_static/images/composition_view_example.png)
-
-```eval_rst
-.. note:: Sanic-OpenAPI does not support routes of `CompositionView` under `Bluebprint` instance now.
-```

--- a/sanic_openapi/utils.py
+++ b/sanic_openapi/utils.py
@@ -1,7 +1,5 @@
 import re
 
-from sanic.views import CompositionView
-
 
 def get_uri_filter(app):
     """
@@ -128,10 +126,7 @@ def get_all_routes(app, skip_prefix):
             # create dict httpMethod -> handler
             # e.g.  {"GET" -> lambda request: response}
 
-            if type(route.handler) is CompositionView:
-                method_handlers = route.handler.handlers
-
-            elif hasattr(route.handler, "view_class"):
+            if hasattr(route.handler, "view_class"):
                 method_handlers = {
                     method: getattr(route.handler.view_class, method.lower())
                     for method in route.methods

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2,7 +2,7 @@ import pytest
 from sanic import Blueprint
 from sanic.constants import HTTP_METHODS
 from sanic.response import text
-from sanic.views import CompositionView, HTTPMethodView
+from sanic.views import HTTPMethodView
 
 METHODS = [method.lower() for method in HTTP_METHODS]
 
@@ -32,11 +32,6 @@ class SimpleView(HTTPMethodView):
 
 def get_handler(request):
     return text("I am a get method")
-
-
-view = CompositionView()
-view.add(["GET"], get_handler)
-view.add(["POST", "PUT"], lambda request: text("I am a post/put method"))
 
 
 def test_swagger_endpoint(app):
@@ -180,36 +175,6 @@ def test_blueprint_class_based_view(app):
         set(swagger_json["paths"]["/"].keys())
     )
     assert {"name": "test"} in swagger_json["tags"]
-
-
-def test_document_compositionview(app):
-    app.add_route(view, "/")
-
-    _, response = app.test_client.get("/swagger/swagger.json")
-    assert response.status == 200
-    assert response.content_type == "application/json"
-
-    swagger_json = response.json
-    assert set(swagger_json["paths"]["/"].keys()) == set(
-        ["get", "post", "put"]
-    )
-    assert {"name": "test"} in swagger_json["tags"]
-
-
-@pytest.mark.skip(reason="Not support now.")
-def test_document_blueprint_compositionview(app):
-
-    bp = Blueprint("test")
-    bp.add_route(view, "/")
-
-    _, response = app.test_client.get("/swagger/swagger.json")
-    assert response.status == 200
-    assert response.content_type == "application/json"
-
-    swagger_json = response.json
-    assert set(swagger_json["paths"]["/"].keys()) == set(
-        ["get", "post", "put"]
-    )
 
 
 def test_swagger_ui_config(app):


### PR DESCRIPTION
`CompositionView` has been deprecated in 21.12.0: https://github.com/sanic-org/sanic/blob/v21.12.0/docs/sanic/releases/21/21.12.md#deprecations-and-removals

Signed-off-by: morph027 <stefan.heitmueller@gmx.com>