### PR TITLE
Adds support for schema inheritance to OAPI3

### DIFF
--- a/sanic_openapi/openapi3/types.py
+++ b/sanic_openapi/openapi3/types.py
@@ -243,7 +243,9 @@ def _serialize(value) -> Any:
 
 def _properties(value: object) -> Dict:
     try:
-        fields = {x: v for x, v in value.__dict__.items()}
+        fields = {
+            key: getattr(value, key) for key in dir(value) if not key.startswith("_")
+        }
     except AttributeError:
         fields = {}
 


### PR DESCRIPTION
This change was done to the OAPI2, and can be ported to the version 3.

```python
class Employee:
    name = doc.String(required=True)

class FullEmployee(Employee):
    phone = doc.String(required=True)
```

Builds schema with both fields for `FullEmployee` model. Without this fix, it's only `phone`.